### PR TITLE
Fix the tests

### DIFF
--- a/FDApy/representation/basis.py
+++ b/FDApy/representation/basis.py
@@ -90,7 +90,7 @@ def _simulate_basis(
         raise NotImplementedError(f"Basis {name!r} not implemented!")
 
     if is_normalized:
-        norm2 = np.sqrt(simpson(values * values, argvals))
+        norm2 = np.sqrt(simpson(values * values, x=argvals))
         values = np.divide(values, norm2[:, np.newaxis])
 
     if add_intercept:

--- a/FDApy/representation/functional_data.py
+++ b/FDApy/representation/functional_data.py
@@ -436,7 +436,7 @@ class FunctionalData(ABC):
         use_argvals_stand: bool = False,
     ) -> npt.NDArray[np.float64]:
         r"""Norm of each observation of the data.
-        
+
         For each observation in the data, it computes its norm defined
         as
 
@@ -731,7 +731,7 @@ class GridFunctionalData(FunctionalData):
         use_argvals_stand: bool = False,
     ) -> npt.NDArray[np.float64]:
         r"""Norm of each observation of the data.
-        
+
         For each observation in the data, it computes its norm defined
         as
 

--- a/tests/test_psplines.py
+++ b/tests/test_psplines.py
@@ -176,7 +176,7 @@ class TestPSplines(unittest.TestCase):
 
     def test_getter(self):
         ps = PSplines(order_penalty=2, order_derivative=2)
-        
+
         ps.order_penalty = 3
         np.testing.assert_equal(ps.order_penalty, 3)
 
@@ -226,7 +226,7 @@ class TestPSplines(unittest.TestCase):
         ps = PSplines(n_segments=3, degree=2)
         ps.fit(self.y, self.x, penalty=(0.5,))
         y_pred = ps.predict(self.x)
-        
+
         np.testing.assert_allclose(y_pred, self.y)
 
     def test_fit_with_multiple_dimensions(self):


### PR DESCRIPTION
Fix the following error when running `pytest`:
```
TypeError: simpson() takes 1 positional argument but 2 were given
```

Fix also the following formatting errors when
running `flake8 FDApy tests`:

```
FDApy/representation/functional_data.py:439:1: W293 blank line contains whitespace
FDApy/representation/functional_data.py:734:1: W293 blank line contains whitespace
tests/test_psplines.py:179:1: W293 blank line contains whitespace
tests/test_psplines.py:229:1: W293 blank line contains whitespace
```