### PR TITLE
JOSS: normalize capitalization in references

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -1,16 +1,16 @@
 @techreport{vanrossumPEP8StyleGuide2001,
   type = {{{PEP}}},
-  title = {{{PEP8}} - {{Style}} Guide for {{Python}} Code},
+  title = {PEP8 - Style Guide for {Python} Code},
   author = {{van Rossum}, Guido and Warsaw, Barry and Coghlan, Alyssa},
   year = {2001},
 }
 
 @book{ramsayFunctionalDataAnalysis2005,
-  title = {Functional {{Data Analysis}}},
+  title = {Functional Data Analysis},
   author = {Ramsay, J. O. and Silverman, B. W.},
   year = {2005},
-  series = {Springer {{Series}} in {{Statistics}}},
-  publisher = {{Springer}},
+  series = {Springer Series in Statistics},
+  publisher = {Springer},
   address = {{New York, NY}},
   urldate = {2023-07-07},
   langid = {english},
@@ -19,20 +19,20 @@
 }
 
 @book{horvathInferenceFunctionalData2012a,
-  title = {Inference for {{Functional Data}} with {{Applications}}},
+  title = {Inference for Functional Data with Applications},
   author = {Horv{\'a}th, Lajos and Kokoszka, Piotr},
   year = {2012},
-  series = {Springer {{Series}} in {{Statistics}}},
+  series = {Springer Series in Statistics},
   volume = {200},
-  publisher = {{Springer}},
-  address = {{New York, NY}},
+  publisher = {Springer},
+  address = {New York, NY},
   urldate = {2023-09-19},
   langid = {english},
   keywords = {functional-data-analysis,functional-time-series,hilbert-space-theory},
 }
 
 @book{kokoszkaIntroductionFunctionalData2017,
-  title = {Introduction to {{Functional Data Analysis}}},
+  title = {Introduction to Functional Data Analysis},
   author = {Kokoszka, Piotr and Reimherr, Matthew},
   year = {2017},
   month = sep,
@@ -52,7 +52,7 @@
 }
 
 @article{happMultivariateFunctionalPrincipal2018,
-  title = {Multivariate {{Functional Principal Component Analysis}} for {{Data Observed}} on {{Different}} ({{Dimensional}}) {{Domains}}},
+  title = {Multivariate Functional Principal Component Analysis for Data Observed on Different (Dimensional) Domains},
   author = {Happ, Clara and Greven, Sonja},
   year = {2018},
   month = apr,
@@ -84,20 +84,6 @@
   doi = {10.1109/camsap.2013.6714047}
 }
 
-@misc{ramos-carrenoScikitfdaPythonPackage2023,
-  title = {Scikit-Fda: {{A Python Package}} for {{Functional Data Analysis}}},
-  shorttitle = {Scikit-Fda},
-  author = {{Ramos-Carre{\~n}o}, Carlos and Torrecilla, Jos{\'e} Luis and {Carbajo-Berrocal}, Miguel and Marcos, Pablo and Su{\'a}rez, Alberto},
-  year = {2023},
-  month = jun,
-  number = {arXiv:2211.02566},
-  eprint = {2211.02566},
-  primaryclass = {cs, stat},
-  publisher = {arXiv},
-  doi = {10.48550/arXiv.2211.02566},
-  urldate = {2024-01-15},
-}
-
 @misc{loningSktimeSktimeV02022,
   title = {Sktime/Sktime: V0.13.4},
   shorttitle = {Sktime/Sktime},
@@ -110,7 +96,7 @@
 }
 
 @article{tavenardTslearnMachineLearning2020,
-  title = {Tslearn, {{A Machine Learning Toolkit}} for {{Time Series Data}}},
+  title = {Tslearn, A Machine Learning Toolkit for Time Series Data},
   author = {Tavenard, Romain and Faouzi, Johann and Vandewiele, Gilles and Divo, Felix and Androz, Guillaume and Holtz, Chester and Payne, Marie and Yurchak, Roman and Ru{\ss}wurm, Marc and Kolar, Kushal and Woods, Eli},
   year = {2020},
   journal = {Journal of Machine Learning Research},
@@ -119,11 +105,11 @@
   pages = {1--6},
   issn = {1533-7928},
   urldate = {2024-01-10},
-  doi = {10.5555/3455716.3455834}
+  url = {http://jmlr.org/papers/v21/20-091.html}
 }
 
 @misc{ramsayFdaFunctionalData2023,
-  title = {Fda: {{Functional Data Analysis}}},
+  title = {Fda: Functional Data Analysis},
   shorttitle = {Fda},
   author = {Ramsay, James and Hooker, Giles and Graves, Spencer},
   year = {2023},
@@ -132,7 +118,7 @@
 }
 
 @book{ramsayFunctionalDataAnalysis2009,
-  title = {Functional {{Data Analysis}} with {{R}} and {{MATLAB}}},
+  title = {Functional Data Analysis with {{R}} and {{MATLAB}}},
   author = {Ramsay, James and Hooker, Giles and Graves, Spencer},
   year = {2009},
   publisher = {Springer},
@@ -144,7 +130,7 @@
 }
 
 @article{brockhausBoostingFunctionalRegression2020,
-  title = {Boosting {{Functional Regression Models}} with {{FDboost}}},
+  title = {Boosting Functional Regression Models with {{FDboost}}},
   author = {Brockhaus, Sarah and R{\"u}gamer, David and Greven, Sonja},
   year = {2020},
   month = sep,
@@ -157,7 +143,7 @@
 }
 
 @misc{goldsmithRefundRegressionFunctional2023,
-  title = {Refund: {{Regression}} with {{Functional Data}}},
+  title = {Refund: Regression with Functional Data},
   shorttitle = {Refund},
   author = {Goldsmith, Jeff and Scheipl, Fabian and Huang, Lei and Wrobel, Julia and Di, Chongzhi and Gellar, Jonathan and Harezlak, Jaroslaw and McLean, Mathew W. and Swihart, Bruce and Xiao, Luo and Crainiceanu, Ciprian and Reiss, Philip T. and Chen, Yakuan and Greven, Sonja and Huo, Lan and Kundu, Madan Gopal and Park, So Young and Miller, David L. and Staicu, Ana-Maria and Cui, Erjia and Li, Ruonan and Li, Zheyuan},
   year = {2023},
@@ -166,7 +152,7 @@
 }
 
 @misc{bouveyronFunFEMClusteringDiscriminative2021,
-  title = {{{funFEM}}: {{Clustering}} in the {{Discriminative Functional Subspace}}},
+  title = {{{funFEM}}: Clustering in the Discriminative Functional Subspace},
   shorttitle = {{{funFEM}}},
   author = {Bouveyron, Charles},
   year = {2021},
@@ -177,7 +163,7 @@
 }
 
 @misc{bouveyronFunLBMModelBasedCoClustering2022,
-  title = {{{funLBM}}: {{Model-Based Co-Clustering}} of {{Functional Data}}},
+  title = {{{funLBM}}: Model-Based Co-Clustering of Functional Data},
   shorttitle = {{{funLBM}}},
   author = {Bouveyron, Charles and Schmutz, Julien Jacques {and} Amandine},
   year = {2022},
@@ -188,7 +174,7 @@
 }
 
 @misc{tuckerFdasrvfElasticFunctional2023,
-  title = {Fdasrvf: {{Elastic Functional Data Analysis}}},
+  title = {Fdasrvf: Elastic Functional Data Analysis},
   shorttitle = {Fdasrvf},
   author = {Tucker, J. Derek and Stamm, Aymeric},
   year = {2023},
@@ -199,7 +185,7 @@
 }
 
 @article{happ-kurzObjectOrientedSoftwareFunctional2020,
-  title = {Object-{{Oriented Software}} for {{Functional Data}}},
+  title = {Object-Oriented Software for Functional Data},
   author = {{Happ-Kurz}, Clara},
   year = {2020},
   month = apr,
@@ -212,7 +198,7 @@
 }
 
 @misc{happ-kurzMFPCAMultivariateFunctional2022,
-  title = {{{MFPCA}}: {{Multivariate Functional Principal Component Analysis}} for {{Data Observed}} on {{Different Dimensional Domains}}},
+  title = {{{MFPCA}}: Multivariate Functional Principal Component Analysis for Data Observed on Different Dimensional Domains},
   shorttitle = {{{MFPCA}}},
   author = {{Happ-Kurz}, Clara},
   year = {2022},
@@ -236,7 +222,7 @@
 }
 
 @article{rizopoulosJMPackageJoint2010,
-  title = {{{JM}}: {{An R Package}} for the {{Joint Modelling}} of {{Longitudinal}} and {{Time-to-Event Data}}},
+  title = {{{JM}}: An {R} Package for the Joint Modelling of Longitudinal and Time-to-Event Data},
   shorttitle = {{{JM}}},
   author = {Rizopoulos, Dimitris},
   year = {2010},
@@ -250,14 +236,14 @@
 
 @inproceedings{sklearn_api,
   title = {{{API}} Design for Machine Learning Software: Experiences from the Scikit-Learn Project},
-  booktitle = {{{ECML PKDD}} Workshop: {{Languages}} for Data Mining and Machine Learning},
+  booktitle = {{{ECML PKDD}} Workshop: Languages for Data Mining and Machine Learning},
   author = {Buitinck, Lars and Louppe, Gilles and Blondel, Mathieu and Pedregosa, Fabian and Mueller, Andreas and Grisel, Olivier and Niculae, Vlad and Prettenhofer, Peter and Gramfort, Alexandre and Grobler, Jaques and Layton, Robert and VanderPlas, Jake and Joly, Arnaud and Holt, Brian and Varoquaux, Ga{\"e}l},
   year = {2013},
   pages = {108--122},
 }
 
 @misc{sortFunctionalGeneralizedCanonical2023,
-  title = {Functional {{Generalized Canonical Correlation Analysis}} for Studying Multiple Longitudinal Variables},
+  title = {Functional Generalized Canonical Correlation Analysis for Studying Multiple Longitudinal Variables},
   author = {Sort, Lucas and Le Brusquet, Laurent and Tenenhaus, Arthur},
   year = {2023},
   month = oct,
@@ -270,7 +256,7 @@
 }
 
 @book{eilersPracticalSmoothingJoys2021,
-  title = {Practical {{Smoothing}}: {{The Joys}} of {{P-splines}}},
+  title = {Practical Smoothing: The Joys of {{P-splines}}},
   shorttitle = {Practical {{Smoothing}}},
   author = {Eilers, Paul H.C. and Marx, Brian D.},
   year = {2021},
@@ -282,7 +268,7 @@
 
 @manual{rcoreteamLanguageEnvironmentStatistical2021,
   type = {Manual},
-  title = {R: A Language and Environment for Statistical Computing},
+  title = {{R}: A Language and Environment for Statistical Computing},
   author = {{R Core Team}},
   year = {2021},
   address = {Vienna, Austria},
@@ -291,7 +277,7 @@
 }
 
 @article{yaoFunctionalDataAnalysis2005,
-  title = {Functional {{Data Analysis}} for {{Sparse Longitudinal Data}}},
+  title = {Functional Data Analysis for Sparse Longitudinal Data},
   author = {Yao, Fang and M{\"u}ller, Hans-Georg and Wang, Jane-Ling},
   year = {2005},
   journal = {Journal of the American Statistical Association},
@@ -306,8 +292,8 @@
 }
 
 @techreport{vanrossumPEP8StyleGuide2001,
-  type = {{{PEP}}},
-  title = {{{PEP8}} - {{Style}} Guide for {{Python}} Code},
+  type = {PEP},
+  title = {{PEP8} - Style Guide for {{Python}} Code},
   author = {{van Rossum}, Guido and Warsaw, Barry and Coghlan, Alyssa},
   year = {2001},
   number = {8},
@@ -315,7 +301,7 @@
 }
 
 @book{horvathInferenceFunctionalData2012a,
-  title = {Inference for {{Functional Data}} with {{Applications}}},
+  title = {Inference for Functional Data with Applications},
   author = {Horv{\'a}th, Lajos and Kokoszka, Piotr},
   year = {2012},
   series = {Springer {{Series}} in {{Statistics}}},
@@ -330,7 +316,7 @@
 
 
 @book{kokoszkaIntroductionFunctionalData2017,
-  title = {Introduction to {{Functional Data Analysis}}},
+  title = {Introduction to Functional Data Analysis},
   author = {Kokoszka, Piotr and Reimherr, Matthew},
   year = {2017},
   month = sep,
@@ -390,7 +376,7 @@
 }
 
 @article{ramos-carrenoScikitfdaPythonPackage2024,
-  title = {Scikit-Fda: {{A Python Package}} for {{Functional Data Analysis}}},
+  title = {Scikit-Fda: A {Python} Package for Functional Data Analysis},
   shorttitle = {Scikit-Fda},
   author = {Ramos-Carreño, Carlos and Torrecilla, José Luis and Carbajo-Berrocal, Miguel and Marcos, Pablo and Suárez, Alberto},
   date = {2024-05-08},
@@ -416,7 +402,7 @@
 }
 
 @misc{ramsayFdaFunctionalData2023,
-  title = {Fda: {{Functional Data Analysis}}},
+  title = {Fda: Functional Data Analysis},
   shorttitle = {Fda},
   author = {Ramsay, James and Hooker, Giles and Graves, Spencer},
   year = {2023},
@@ -426,7 +412,7 @@
 }
 
 @book{ramsayFunctionalDataAnalysis2009,
-  title = {Functional {{Data Analysis}} with {{R}} and {{MATLAB}}},
+  title = {Functional Data Analysis with {{R}} and {{MATLAB}}},
   author = {Ramsay, James and Hooker, Giles and Graves, Spencer},
   year = {2009},
   publisher = {Springer},
@@ -438,7 +424,7 @@
 }
 
 @article{brockhausBoostingFunctionalRegression2020,
-  title = {Boosting {{Functional Regression Models}} with {{FDboost}}},
+  title = {Boosting Functional Regression Models with {{FDboost}}},
   author = {Brockhaus, Sarah and R{\"u}gamer, David and Greven, Sonja},
   year = {2020},
   month = sep,
@@ -451,7 +437,7 @@
 }
 
 @misc{goldsmithRefundRegressionFunctional2023,
-  title = {Refund: {{Regression}} with {{Functional Data}}},
+  title = {Refund: Regression with Functional Data},
   shorttitle = {Refund},
   author = {Goldsmith, Jeff and Scheipl, Fabian and Huang, Lei and Wrobel, Julia and Di, Chongzhi and Gellar, Jonathan and Harezlak, Jaroslaw and McLean, Mathew W. and Swihart, Bruce and Xiao, Luo and Crainiceanu, Ciprian and Reiss, Philip T. and Chen, Yakuan and Greven, Sonja and Huo, Lan and Kundu, Madan Gopal and Park, So Young and Miller, David L. and Staicu, Ana-Maria and Cui, Erjia and Li, Ruonan and Li, Zheyuan},
   year = {2023},


### PR DESCRIPTION
Minor corrections for the bib file to get consistent capitalization in the references in line with JOSS's bibliography style.

openjournals/joss-reviews#7526